### PR TITLE
feat: Add direct doctor relationship to medicines

### DIFF
--- a/backend/src/models/medicine.py
+++ b/backend/src/models/medicine.py
@@ -12,6 +12,7 @@ class Medicine(Base):
     id = Column(Integer, primary_key=True, index=True)
     user_id = Column(Integer, ForeignKey("users.id"), nullable=False, index=True)
     appointment_id = Column(Integer, ForeignKey("appointments.id"), nullable=True, index=True)
+    doctor_id = Column(Integer, ForeignKey("doctors.id"), nullable=True, index=True)
     name = Column(String, nullable=False)
     dosage = Column(String, nullable=False)
     frequency = Column(String, nullable=False)
@@ -22,6 +23,7 @@ class Medicine(Base):
     # Relationships
     user = relationship("User", foreign_keys=[user_id], backref="medicines")
     appointment = relationship("Appointment", back_populates="medicines")
+    doctor = relationship("Doctor", backref="medicines")
 
     def __repr__(self):
         return f"<Medicine(id={self.id}, user_id={self.user_id}, name='{self.name}')>"

--- a/backend/src/schemas/medicine.py
+++ b/backend/src/schemas/medicine.py
@@ -12,6 +12,8 @@ class MedicineBase(BaseModel):
 
 class MedicineCreate(MedicineBase):
     user_id: int = Field(..., example=1, description="ID of the user taking the medicine")
+    doctor_id: Optional[int] = Field(None, example=1, description="ID of the doctor who issued the medicine")
+    appointment_id: Optional[int] = Field(None, example=1, description="ID of the appointment associated with the medicine")
 
 class MedicineUpdate(BaseModel):
     name: Optional[str] = Field(None, example="Paracetamol")
@@ -24,6 +26,8 @@ class MedicineUpdate(BaseModel):
 class MedicineResponse(MedicineBase):
     id: int = Field(..., example=1)
     user_id: int = Field(..., example=1)
+    doctor_id: Optional[int] = Field(None, example=1)
+    appointment_id: Optional[int] = Field(None, example=1)
 
     class Config:
         from_attributes = True

--- a/backend/tests/test_medicines.py
+++ b/backend/tests/test_medicines.py
@@ -6,6 +6,9 @@ from src.models.user import User
 from src.schemas.user import UserCreate
 from src.services.user_service import UserService
 from src.core.config import settings
+from src.models.doctor import Doctor
+from src.models.appointment import Appointment
+from datetime import date, time
 
 ## TODO: Add more tests for the Medicine API
 ## TODO: Add unit tests for the Medicine service
@@ -37,13 +40,38 @@ class TestMedicines:
         test_db.refresh(user)
         return user.id
 
+    def create_doctor(self, test_db):
+        """Helper to create a doctor for testing"""
+        doctor = Doctor(name="Test Doctor", location="Test Hospital")
+        test_db.add(doctor)
+        test_db.commit()
+        test_db.refresh(doctor)
+        return doctor.id
+
+    def create_appointment(self, test_db, user_id, doctor_id):
+        """Helper to create an appointment for testing"""
+        appointment = Appointment(
+            user_id=user_id,
+            doctor_id=doctor_id,
+            name="Test Appointment",
+            date=date(2025, 7, 19),
+            time=time(10, 0),
+            notes="Test appointment notes"
+        )
+        test_db.add(appointment)
+        test_db.commit()
+        test_db.refresh(appointment)
+        return appointment.id
+
     def test_medicine_crud(self, client, test_db):
         """Test medicine CRUD operations"""
-         # Set up authenticated session for document creation (RequireAuth)
+        # Set up authenticated session for document creation (RequireAuth)
         user, session_token = self.create_authenticated_session(client, test_db)
         user_id = user.id
+        doctor_id = self.create_doctor(test_db)
+        appointment_id = self.create_appointment(test_db, user_id, doctor_id)
 
-        # Create medicine
+        # Create medicine with doctor_id and appointment_id
         medicine_data = {
             "name": "Paracetamol",
             "dosage": "500mg",
@@ -52,13 +80,16 @@ class TestMedicines:
             "end_date": "2025-07-05",
             "notes": "Take with food",
             "user_id": user_id,
+            "doctor_id": doctor_id,
+            "appointment_id": appointment_id
         }
         response = client.post("/api/v1/medicines/", json=medicine_data)
-        print(response.json())  # Debugging line to see the response
         assert response.status_code == 200 or response.status_code == 201
         medicine = response.json()
         assert medicine["name"] == medicine_data["name"]
         assert medicine["user_id"] == user_id
+        assert medicine["doctor_id"] == doctor_id
+        assert medicine["appointment_id"] == appointment_id
         medicine_id = medicine["id"]
 
         # Get all medicines for user
@@ -66,20 +97,42 @@ class TestMedicines:
         assert response.status_code == 200
         medicines = response.json()
         assert len(medicines) == 1
-        assert medicines[0]["name"] == medicine_data["name"]
 
-        # Update medicine
+        # Update medicine (should not update doctor_id or appointment_id)
         update_data = {"name": "Ibuprofen"}
         response = client.put(f"/api/v1/medicines/{medicine_id}", json=update_data)
         assert response.status_code == 200
         updated = response.json()
         assert updated["name"] == "Ibuprofen"
+        assert updated["doctor_id"] == doctor_id
+        assert updated["appointment_id"] == appointment_id
 
         # Delete medicine
         response = client.delete(f"/api/v1/medicines/{medicine_id}")
         assert response.status_code == 200
-        
         # Confirm deletion
         response = client.get(f"/api/v1/medicines/user/{user_id}")
         assert response.status_code == 200
         assert response.json() == []
+
+    def test_create_medicine_without_appointment(self, client, test_db):
+        user, session_token = self.create_authenticated_session(client, test_db)
+        user_id = user.id
+        doctor_id = self.create_doctor(test_db)
+        medicine_data = {
+            "name": "Aspirin",
+            "dosage": "100mg",
+            "frequency": "Twice a day",
+            "start_date": "2025-07-01",
+            "end_date": "2025-07-10",
+            "notes": "Take with water",
+            "user_id": user_id,
+            "doctor_id": doctor_id
+        }
+        response = client.post("/api/v1/medicines/", json=medicine_data)
+        assert response.status_code == 200 or response.status_code == 201
+        medicine = response.json()
+        assert medicine["name"] == medicine_data["name"]
+        assert medicine["doctor_id"] == doctor_id
+        assert medicine["user_id"] == user_id
+        assert medicine.get("appointment_id") is None


### PR DESCRIPTION
Allow associating medicines directly with a doctor, without the need for an appointment.

- Add doctor_id to Medicine model and schemas.
- Update tests to reflect schema changes and cover direct association.

Fixes #27